### PR TITLE
Add Streamlit web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # sunsets
 Predicting beautiful sunsets
+
+## Web App
+
+A simple Streamlit application allows exploring the sunset score for various locations. Pick a city from the dropdown or click on the map to choose custom coordinates and press "Get Sunset Score".
+
+### Running locally
+
+```bash
+pip install -r requirements.txt
+streamlit run streamlit_app.py
+```
+
+The app can also be deployed for free on [Streamlit Community Cloud](https://streamlit.io/cloud) by connecting this repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 requests
+streamlit
+folium
+streamlit-folium

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,43 @@
+import streamlit as st
+import sunset_prediction as sp
+from streamlit_folium import st_folium
+import folium
+
+st.set_page_config(page_title="Sunset Score", page_icon="☀️", layout="wide")
+
+st.title("Sunset Score Explorer")
+
+POPULAR = {
+    "Tel Aviv": (32.0853, 34.7818),
+    "New York": (40.7128, -74.0060),
+    "London": (51.5074, -0.1278),
+    "Tokyo": (35.6895, 139.6917),
+    "Sydney": (-33.8688, 151.2093),
+}
+
+location = st.selectbox("Select a popular location", list(POPULAR.keys()))
+lat, lon = POPULAR[location]
+
+st.write("Or pick a custom location by clicking on the map below:")
+
+m = folium.Map(location=[lat, lon], zoom_start=4)
+folium.Marker([lat, lon], tooltip=location).add_to(m)
+click_data = st_folium(m, width=700, height=500)
+if click_data.get("last_clicked"):
+    lat = click_data["last_clicked"]["lat"]
+    lon = click_data["last_clicked"]["lng"]
+
+st.write(f"Current coordinates: {lat:.4f}, {lon:.4f}")
+
+if st.button("Get Sunset Score"):
+    with st.spinner("Fetching data..."):
+        sunset_time = sp.fetch_sunset_time(lat, lon)
+        weather = sp.fetch_weather(lat, lon)
+        air = sp.fetch_air_quality(lat, lon)
+        target_hour = sunset_time.replace(minute=0, second=0, microsecond=0)
+        score, variables = sp.compute_score(weather, air, target_hour)
+        st.subheader("Results")
+        st.write("Sunset time (UTC)", sunset_time)
+        st.json(variables)
+        st.metric("Sunset score", f"{score:.2f}")
+

--- a/sunset_prediction.py
+++ b/sunset_prediction.py
@@ -52,7 +52,7 @@ def fetch_air_quality(lat: float, lon: float) -> dict:
 
 
 
-def compute_score(weather: dict, aq: dict, target_hour: datetime.datetime) -> float:
+def compute_score(weather: dict, aq: dict, target_hour: datetime.datetime) -> tuple[float, dict]:
     logging.debug('Computing sunset score')
     hourly = weather['hourly']
     target_str = target_hour.strftime('%Y-%m-%dT%H:00')
@@ -86,7 +86,15 @@ def compute_score(weather: dict, aq: dict, target_hour: datetime.datetime) -> fl
         aod,
         dust,
     )
-    return score
+    variables = {
+        "high_cloud": high_cloud,
+        "low_cloud": low_cloud,
+        "rh700": rh700,
+        "pm25": pm25,
+        "aod": aod,
+        "dust": dust,
+    }
+    return score, variables
 
 
 def main():
@@ -96,7 +104,7 @@ def main():
 
     # choose hour nearest to sunset
     target_hour = sunset_time.replace(minute=0, second=0, microsecond=0)
-    score = compute_score(weather, air_quality, target_hour)
+    score, variables = compute_score(weather, air_quality, target_hour)
     aq_hourly = air_quality['hourly']
     target_str = target_hour.strftime('%Y-%m-%dT%H:00')
     aq_idx = aq_hourly['time'].index(target_str)
@@ -106,6 +114,7 @@ def main():
     print('Weather data sample:', weather['hourly']['time'][:3])
     print('Air quality sample:', air_quality['hourly']['time'][:3])
     print('PM2.5:', pm25)
+    print('Variables:', variables)
     print('Sunset score:', score)
 
 


### PR DESCRIPTION
## Summary
- support returning variables from compute_score
- add a Streamlit-based `streamlit_app.py`
- document running the app in the README
- list new dependencies
- refine web UI formatting

## Testing
- `python -m py_compile sunset_prediction.py streamlit_app.py`
- `pip install -r requirements.txt`
- `streamlit run streamlit_app.py` (started successfully)


------
https://chatgpt.com/codex/tasks/task_e_6883756cb6f4832cb684455e5cee7283